### PR TITLE
build: bump vulnerable off-chain npm test-client deps to clear Dependabot advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,25 +1,29 @@
 {
-    "scripts": {
-        "lint:fix": "prettier */*.js \"*/**/*{.js,.ts}\" -w",
-        "lint": "prettier */*.js \"*/**/*{.js,.ts}\" --check"
-    },
-    "dependencies": {
-        "@coral-xyz/anchor": "^0.29.0"
-    },
-    "devDependencies": {
-        "@types/bn.js": "^5.1.0",
-        "@types/chai": "^4.3.0",
-        "@types/mocha": "^9.0.0",
-        "chai": "^4.3.4",
-        "mocha": "^9.0.3",
-        "prettier": "^2.6.2",
-        "ts-mocha": "^8.0.0",
-        "typescript": "^4.3.5",
-        "@solana/spl-token": "0.3.8",
-        "@solana/web3.js": "^1.91.1",
-        "@orca-so/whirlpools-sdk": "^0.11.4",
-        "@orca-so/common-sdk": "^0.3.3",
-        "decimal.js": "^10.3.1",
-        "expect": "^29.7.0"
-    }
+  "scripts": {
+    "lint:fix": "prettier */*.js \"*/**/*{.js,.ts}\" -w",
+    "lint": "prettier */*.js \"*/**/*{.js,.ts}\" --check"
+  },
+  "dependencies": {
+    "@coral-xyz/anchor": "^0.29.0"
+  },
+  "devDependencies": {
+    "@types/bn.js": "^5.1.0",
+    "@types/chai": "^4.3.0",
+    "@types/mocha": "^9.0.0",
+    "chai": "^4.3.4",
+    "mocha": "^9.0.3",
+    "prettier": "^2.6.2",
+    "ts-mocha": "^8.0.0",
+    "typescript": "^4.3.5",
+    "@solana/spl-token": "0.3.8",
+    "@solana/web3.js": "^1.91.1",
+    "@orca-so/whirlpools-sdk": "^0.11.4",
+    "@orca-so/common-sdk": "^0.3.3",
+    "decimal.js": "^10.3.1",
+    "expect": "^29.7.0"
+  },
+  "resolutions": {
+    "base-x": ">=3.0.11",
+    "ws": ">=8.20.1"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -427,12 +427,10 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base-x@^3.0.2:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.9.tgz#6349aaabb58526332de9f60995e548a53fe21320"
-  integrity sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==
-  dependencies:
-    safe-buffer "^5.0.1"
+base-x@>=3.0.11, base-x@^3.0.2:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-5.0.1.tgz#16bf35254be1df8aca15e36b7c1dda74b2aa6b03"
+  integrity sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==
 
 base64-js@^1.3.1, base64-js@^1.5.1:
   version "1.5.1"
@@ -1273,7 +1271,7 @@ rpc-websockets@^7.5.1:
     bufferutil "^4.0.1"
     utf-8-validate "^5.0.2"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.0:
+safe-buffer@^5.1.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -1511,15 +1509,10 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@^7.4.5:
-  version "7.5.9"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
-  integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
-
-ws@^8.5.0:
-  version "8.16.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.16.0.tgz#d1cd774f36fbc07165066a60e40323eab6446fd4"
-  integrity sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==
+ws@>=8.20.1, ws@^7.4.5, ws@^8.5.0:
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
Bumps the flagged **off-chain npm test-client** dependencies via a yarn `resolutions` pin. These packages run only in the TypeScript test/integration client — **none are part of the on-chain Rust/SBF program**, so the deployed program is unaffected. (The flagged *cargo* crates are handled separately — they are on-chain and tracked as maintainer review issues.)

## Changes
- `package.json`: `resolutions` pin for each fixable flagged package.
- `yarn.lock`: regenerated.

## Resolved versions
- `base-x` -> **5.0.1** (floor >= 3.0.11)
- `ws` -> **8.21.0** (floor >= 8.20.1)

## Verification
- `yarn install` — clean (npm tree resolves with the bumped versions).
- `tsc --noEmit` — errors (pre-existing: TS tests import anchor-generated target/types not built locally)
- `yarn lint` — errors (pre-existing, unrelated to dep bump)
> These repos have no CI workflow and no build/test npm script; the TS client's full type-check needs `anchor build`-generated `target/types` (Solana toolchain). `yarn install` resolving cleanly is the meaningful check for an off-chain npm bump.

## Issues closed
- #17 [Security][high] ws (npm): 3 advisories — bump >= 8.20.1
- #8 [Security][high] base-x (npm): 1 advisory — bump >= 3.0.11

## Not fixed here (no upstream patch)
- #9 [Security][high] bigint-buffer (npm): 1 advisory — bump >= latest — **no upstream fix**; left open

Closes #17
Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
